### PR TITLE
Use standard encoding for virtual offset (coffset<<16|uoffset)

### DIFF
--- a/bam-index/src/main/java/org/victorchang/KeyPointer.java
+++ b/bam-index/src/main/java/org/victorchang/KeyPointer.java
@@ -56,7 +56,7 @@ public class KeyPointer implements Comparable<KeyPointer> {
     public String toString() {
         return new StringJoiner(", ")
                 .add("coffset=" + PointerPacker.INSTANCE.unpackCompressedOffset(pointer))
-                .add("uoffset=" + PointerPacker.INSTANCE.unpackUnCompressedOffset(pointer))
+                .add("uoffset=" + PointerPacker.INSTANCE.unpackUncompressedOffset(pointer))
                 .add("key=" + Ascii7Coder.INSTANCE.decode(key, 0, key.length))
                 .toString();
     }

--- a/bam-index/src/main/java/org/victorchang/QnameSearcher.java
+++ b/bam-index/src/main/java/org/victorchang/QnameSearcher.java
@@ -50,7 +50,7 @@ public class QnameSearcher {
         Path pathLevel0 = indexFolder.resolve("qname.0");
         FileChannel channelLevel0 = FileChannel.open(pathLevel0, READ);
         long coffset = PointerPacker.INSTANCE.unpackCompressedOffset(start.getPointer());
-        int uoffset = PointerPacker.INSTANCE.unpackUnCompressedOffset(start.getPointer());
+        int uoffset = PointerPacker.INSTANCE.unpackUncompressedOffset(start.getPointer());
 
         if (coffset >= channelLevel0.size()) {
             return 0;

--- a/bam-reader/src/main/java/org/victorchang/DefaultBamRecordReader.java
+++ b/bam-reader/src/main/java/org/victorchang/DefaultBamRecordReader.java
@@ -47,7 +47,7 @@ public class DefaultBamRecordReader implements BamRecordReader {
     @Override
     public void read(Path bamFile, long pointer, BamRecordHandler recordHandler) throws IOException {
         long coffset = PointerPacker.INSTANCE.unpackCompressedOffset(pointer);
-        int uoffset = PointerPacker.INSTANCE.unpackUnCompressedOffset(pointer);
+        int uoffset = PointerPacker.INSTANCE.unpackUncompressedOffset(pointer);
         read(bamFile, coffset, uoffset, recordHandler);
     }
 }

--- a/bam-reader/src/main/java/org/victorchang/PointerPacker.java
+++ b/bam-reader/src/main/java/org/victorchang/PointerPacker.java
@@ -1,8 +1,12 @@
 package org.victorchang;
 
+import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
+
 /**
  * Packs compressed offset {@code coffset} and uncompressed offset {@code uoffset} into a pointer {@code voffset}
  * which is 64 bit long. It assumes that 0 <= coffset < 2^48 and 0 <= uoffset < 2^16.
+ *
+ * @see <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAMv1 spec</a>
  */
 public final class PointerPacker {
     public static PointerPacker INSTANCE = new PointerPacker();
@@ -11,20 +15,14 @@ public final class PointerPacker {
     }
 
     public long pack(long coffset, int uoffset) {
-        if ((coffset & 0xffff000000000000L) != 0L) {
-            throw new IllegalArgumentException("Block position must be less than 2^48");
-        }
-        if ((uoffset & 0xffff0000) != 0) {
-            throw new IllegalArgumentException("Offset must be less than 2^16");
-        }
-        return (coffset | (long)uoffset << 48);
+        return BlockCompressedFilePointerUtil.makeFilePointer(coffset, uoffset);
     }
 
     public long unpackCompressedOffset(long voffset) {
-        return (voffset & 0x0000fffffffffffL);
+        return BlockCompressedFilePointerUtil.getBlockAddress(voffset);
     }
 
-    public int unpackUnCompressedOffset(long voffset) {
-        return (int)(voffset >> 48 & 0xffff);
+    public int unpackUncompressedOffset(long voffset) {
+        return BlockCompressedFilePointerUtil.getBlockOffset(voffset);
     }
 }

--- a/bam-reader/src/test/java/org/victorchang/PointerPackerTest.java
+++ b/bam-reader/src/test/java/org/victorchang/PointerPackerTest.java
@@ -1,5 +1,6 @@
 package org.victorchang;
 
+import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -9,9 +10,15 @@ public class PointerPackerTest {
 
     @Test
     public void testPackUnpack() {
-        long pos = PointerPacker.INSTANCE.pack(36300895L, 59353);
+        roundtrip(36300895L, 59353);
+        roundtrip(0, 0);
+        roundtrip(BlockCompressedFilePointerUtil.MAX_BLOCK_ADDRESS, BlockCompressedFilePointerUtil.MAX_OFFSET);
+    }
 
-        assertThat(PointerPacker.INSTANCE.unpackCompressedOffset(pos), equalTo(36300895L));
-        assertThat(PointerPacker.INSTANCE.unpackUnCompressedOffset(pos), equalTo(59353));
+    private static void roundtrip(long coffset, int uoffset) {
+        long pos = PointerPacker.INSTANCE.pack(coffset, uoffset);
+
+        assertThat(PointerPacker.INSTANCE.unpackCompressedOffset(pos), equalTo(coffset));
+        assertThat(PointerPacker.INSTANCE.unpackUncompressedOffset(pos), equalTo(uoffset));
     }
 }


### PR DESCRIPTION
Not sure why we were using something different before. Also, just use
the classes from the library now that we use it.

<img width="1007" alt="Screen Shot 2020-09-22 at 15 32 20" src="https://user-images.githubusercontent.com/16778/93966366-ddc0fe80-fda7-11ea-942d-0fec2666bca1.png">
