### PR TITLE
Set compression level back to 6, add CLI option

### DIFF
--- a/bam-cmd/bam-cmd.iml
+++ b/bam-cmd/bam-cmd.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="CheckStyle-IDEA-Module">
-    <option name="configuration">
-      <map />
-    </option>
-  </component>
-  <component name="ExternalSystem" externalSystem="Maven" />
-</module>

--- a/bam-cmd/src/main/java/org/victorchang/QnameCommand.java
+++ b/bam-cmd/src/main/java/org/victorchang/QnameCommand.java
@@ -68,6 +68,8 @@ class IndexCommand implements Callable<Integer> {
     boolean verbose;
     @Option(names = {"--force" }, description = "Overwrite existing index", defaultValue = "false")
     boolean force;
+    @Option(names = {"--compression"}, description = "Compression level (1 to 9). 1 = faster but bigger index file size, 9 = slower but smaller index file size", defaultValue = "6")
+    int compressionLevel;
 
     @Override
     public Integer call() {
@@ -92,7 +94,7 @@ class IndexCommand implements Callable<Integer> {
 
         BamFileReader fileReader = new DefaultBamFileReader(new EfficientBamRecordParser());
         QnameIndexer indexer = new QnameIndexer(fileReader,
-                new KeyPointerWriter(),
+                new KeyPointerWriter(compressionLevel),
                 new KeyPointerReader(),
                 threadCount,
                 sortBufferSize);

--- a/bam-index/src/main/java/org/victorchang/KeyPointerWriter.java
+++ b/bam-index/src/main/java/org/victorchang/KeyPointerWriter.java
@@ -8,11 +8,23 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
+import java.util.zip.Deflater;
 
 /**
  * Write a stream of {@link KeyPointer} into a concatenated gzip output.
  */
 public class KeyPointerWriter {
+
+    private final int compressionLevel;
+
+    public KeyPointerWriter(int compressionLevel) {
+        this.compressionLevel = compressionLevel;
+    }
+
+    public KeyPointerWriter() {
+        this(Deflater.DEFAULT_COMPRESSION);
+    }
+
     public List<KeyPointer> write(OutputStream outputStream, Stream<KeyPointer> stream) throws IOException {
         return write(outputStream, stream, Long.MAX_VALUE);
     }
@@ -20,7 +32,7 @@ public class KeyPointerWriter {
     @SuppressWarnings("UnstableApiUsage")
     public List<KeyPointer> write(OutputStream outputStream, Stream<KeyPointer> stream, long blockSize) throws IOException {
         GzipConcatenatedOutputStream concatenatedStream =
-                new GzipConcatenatedOutputStream(outputStream, 1 << 16);
+                new GzipConcatenatedOutputStream(outputStream, 1 << 16, compressionLevel);
 
         LittleEndianDataOutputStream dataOutput = new LittleEndianDataOutputStream(concatenatedStream);
 

--- a/bam-index/src/main/java/org/victorchang/QnameIndexer.java
+++ b/bam-index/src/main/java/org/victorchang/QnameIndexer.java
@@ -18,10 +18,7 @@ import java.util.stream.BaseStream;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.nio.file.StandardOpenOption.CREATE;
-import static java.nio.file.StandardOpenOption.READ;
-import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
-import static java.nio.file.StandardOpenOption.WRITE;
+import static java.nio.file.StandardOpenOption.*;
 
 public class QnameIndexer {
     private static final Logger log = LoggerFactory.getLogger(QnameIndexer.class);

--- a/bam-reader/bam-reader.iml
+++ b/bam-reader/bam-reader.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="CheckStyle-IDEA-Module">
-    <option name="configuration">
-      <map />
-    </option>
-  </component>
-  <component name="ExternalSystem" externalSystem="Maven" />
-</module>

--- a/bam-reader/src/main/java/org/victorchang/GzipConcatenatedOutputStream.java
+++ b/bam-reader/src/main/java/org/victorchang/GzipConcatenatedOutputStream.java
@@ -5,7 +5,6 @@ import org.apache.commons.compress.utils.CountingOutputStream;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.zip.Deflater;
 import java.util.zip.GZIPOutputStream;
 
 public class GzipConcatenatedOutputStream extends OutputStream {
@@ -13,14 +12,16 @@ public class GzipConcatenatedOutputStream extends OutputStream {
 
     private final OutputStream outputStream;
     private final int uncompressedSize;
+    private final int compressionLevel;
 
     private CountingOutputStream uncompressedStream;
     private CountingOutputStream compressedStream;
     private long compressedCount;
 
-    public GzipConcatenatedOutputStream(OutputStream outputStream, int uncompressedSize) throws IOException {
+    public GzipConcatenatedOutputStream(OutputStream outputStream, int uncompressedSize, int compressionLevel) throws IOException {
         this.outputStream = outputStream;
         this.uncompressedSize = uncompressedSize;
+        this.compressionLevel = compressionLevel;
         compressedCount = 0;
         nextEntry();
     }
@@ -77,15 +78,15 @@ public class GzipConcatenatedOutputStream extends OutputStream {
                 flush();
             }
         };
-        OutputStream gzipOutputStream = new ConfigurableGZIPOutputStream(compressedStream);
+        OutputStream gzipOutputStream = new ConfigurableGZIPOutputStream(compressedStream, compressionLevel);
         uncompressedStream = new CountingOutputStream(new BufferedOutputStream(gzipOutputStream, FILE_BUFF_SIZE));
     }
 
     static class ConfigurableGZIPOutputStream extends GZIPOutputStream {
 
-        public ConfigurableGZIPOutputStream(OutputStream out) throws IOException {
+        public ConfigurableGZIPOutputStream(OutputStream out, int compressionLevel) throws IOException {
             super(out);
-            def.setLevel(Deflater.BEST_COMPRESSION);
+            def.setLevel(compressionLevel);
         }
     }
 }

--- a/bam-reader/src/test/java/org/victorchang/GzipConcatenatedOutputStreamTest.java
+++ b/bam-reader/src/test/java/org/victorchang/GzipConcatenatedOutputStreamTest.java
@@ -15,7 +15,7 @@ public class GzipConcatenatedOutputStreamTest {
     @Test
     public void testCreateConcatenatedGzip() throws IOException {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        GzipConcatenatedOutputStream concatenatedOutput = new GzipConcatenatedOutputStream(output, 512);
+        GzipConcatenatedOutputStream concatenatedOutput = new GzipConcatenatedOutputStream(output, 512, 6);
         byte[] buffer = new byte[384];
         concatenatedOutput.write(buffer);
         concatenatedOutput.write(buffer, 0, buffer.length);


### PR DESCRIPTION
Level 9 is about half as fast as level 6, for a gain of about 10%. Add
it as an option if index size is a concern, but default should probably
be 6.