### PR TITLE
Make logging format a bit more friendly (single line, less noise)

### DIFF
--- a/bam-cmd/src/main/java/org/victorchang/IndexCommand.java
+++ b/bam-cmd/src/main/java/org/victorchang/IndexCommand.java
@@ -57,8 +57,7 @@ class IndexCommand implements Callable<Integer> {
 
     @Override
     public Integer call() {
-        java.util.logging.Logger.getLogger("")
-                .setLevel(verbose ? java.util.logging.Level.ALL : java.util.logging.Level.SEVERE);
+        Logging.configure(verbose);
 
         if (!Files.isRegularFile(bamPath)) {
             System.err.println(bamPath + " not found.");

--- a/bam-cmd/src/main/java/org/victorchang/Logging.java
+++ b/bam-cmd/src/main/java/org/victorchang/Logging.java
@@ -1,0 +1,15 @@
+package org.victorchang;
+
+import java.util.logging.Level;
+
+public class Logging {
+
+    public static void configure(boolean verbose) {
+        Level level = verbose ? Level.ALL : Level.SEVERE;
+        java.util.logging.Logger.getLogger("").setLevel(level);
+
+        // More friendly single-line logging format
+        System.setProperty("java.util.logging.SimpleFormatter.format",
+                "[%1$tF %1$tT] [%4$-7s] %5$s %n");
+    }
+}

--- a/bam-cmd/src/main/java/org/victorchang/ViewCommand.java
+++ b/bam-cmd/src/main/java/org/victorchang/ViewCommand.java
@@ -49,8 +49,7 @@ class ViewCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        java.util.logging.Logger.getLogger("")
-                .setLevel(verbose ? java.util.logging.Level.ALL : java.util.logging.Level.SEVERE);
+        Logging.configure(verbose);
 
         if (!Files.isRegularFile(bamPath)) {
             System.err.println(bamPath + " not found.");


### PR DESCRIPTION
Before:

```
INFO: First 5 index blocks
Sep. 25, 2020 3:19:20 PM org.victorchang.QnameIndexer lambda$index$2
INFO: coffset=0, uoffset=62110, key=SOLEXA-1GA-1_1_FC20EMA:7:100:434:814
Sep. 25, 2020 3:19:20 PM org.victorchang.QnameIndexer lambda$index$2
INFO: coffset=13166, uoffset=58664, key=SOLEXA-1GA-1_1_FC20EMA:7:100:756:128
Sep. 25, 2020 3:19:20 PM org.victorchang.QnameIndexer lambda$index$2
INFO: coffset=26279, uoffset=55210, key=SOLEXA-1GA-1_1_FC20EMA:7:101:176:385
Sep. 25, 2020 3:19:20 PM org.victorchang.QnameIndexer lambda$index$2
INFO: coffset=39389, uoffset=51782, key=SOLEXA-1GA-1_1_FC20EMA:7:101:507:820
Sep. 25, 2020 3:19:20 PM org.victorchang.QnameIndexer lambda$index$2
INFO: coffset=52405, uoffset=48344, key=SOLEXA-1GA-1_1_FC20EMA:7:101:814:100
Sep. 25, 2020 3:19:20 PM org.victorchang.IndexCommand call
INFO: Create index completed in 10395ms
```

After:

```
[2020-09-25 15:18:38] [INFO   ] First 5 index blocks
[2020-09-25 15:18:38] [INFO   ] coffset=0, uoffset=62110, key=SOLEXA-1GA-1_1_FC20EMA:7:100:434:814
[2020-09-25 15:18:38] [INFO   ] coffset=13166, uoffset=58664, key=SOLEXA-1GA-1_1_FC20EMA:7:100:756:128
[2020-09-25 15:18:38] [INFO   ] coffset=26279, uoffset=55210, key=SOLEXA-1GA-1_1_FC20EMA:7:101:176:385
[2020-09-25 15:18:38] [INFO   ] coffset=39389, uoffset=51782, key=SOLEXA-1GA-1_1_FC20EMA:7:101:507:820
[2020-09-25 15:18:38] [INFO   ] coffset=52405, uoffset=48344, key=SOLEXA-1GA-1_1_FC20EMA:7:101:814:100
[2020-09-25 15:18:38] [INFO   ] Create index completed in 7476ms
```