### PR TITLE
Only use a single byte for length in KeyPointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# QNAME search
+# atlantool for QNAME search
 
 Tool for:
 
@@ -50,7 +50,9 @@ SOLEXA-1GA-1_0047_FC62472:5:52:15203:7914#0	0	chr1	10158	25	36M	*	0	0	AACCCTAACC
 
 ## Performance
 
-Indexing time depends on the size and the number of records in BAM file. At the moment the indexing time for a 140 GB BAM file of 1.2 billion records using 8 threads is around 2 hours. It generates index files of 12 GB. Query time is sub second.
+Indexing time depends on the size and the number of records in BAM file.
+At the moment the indexing time for a 140 GB BAM file of 1.2 billion records using 8 threads is around 1 hour (depending on hardware).
+It generates index files of 12 GB. Query time is sub second.
 
 ## Index file format
 
@@ -59,12 +61,12 @@ Both are in BGZF format as described in [SAMv1.pdf].
 The data is in the following format (numbers are in little endian):
 
 ```
-xx xx   2 bytes: length of entry (N)
-xx...   N-8 bytes: QNAME (key)
+xx      1 byte: length of QNAME (N)
+xx...   N bytes: QNAME (key)
 xx xx xx xx xx xx xx xx: 8 bytes: virtual offset (pointer)
 ```
 
-The pointer is encoded as `(coffset << 16) | uoffset`.
+The pointer is encoded as `(coffset << 16) | uoffset` (same as in BAM format).
 
 ### `qname.data.bgz`
 

--- a/bam-index/src/main/java/org/victorchang/IndexVersion.java
+++ b/bam-index/src/main/java/org/victorchang/IndexVersion.java
@@ -7,7 +7,7 @@ public abstract class IndexVersion {
     public static final IndexVersion LATEST = new IndexVersion() {
         @Override
         public String fileName(String type) {
-            return "qname.v" + version() + "." + type +  ".bgz";
+            return "qname.v" + version() + "." + type + ".bgz";
         }
 
         /**
@@ -15,7 +15,7 @@ public abstract class IndexVersion {
          */
         @Override
         public int version() {
-            return 2;
+            return 3;
         }
 
         @Override
@@ -25,5 +25,6 @@ public abstract class IndexVersion {
     };
 
     public abstract String fileName(String ext);
+
     public abstract int version();
 }

--- a/bam-index/src/main/java/org/victorchang/KeyPointerReader.java
+++ b/bam-index/src/main/java/org/victorchang/KeyPointerReader.java
@@ -36,22 +36,22 @@ public class KeyPointerReader {
             /**
              * reusable buffer to minimize memory allocation.
              */
-            private final byte[] inputBuff = new byte[256 + 8 + 2];
+            private final byte[] inputBuff = new byte[256];
             private KeyPointer current = null;
 
             @Override
             public boolean hasNext() {
                 if (current == null) {
                     try {
-                        int entryLen;
+                        int keyLen;
                         try {
-                            entryLen = dataInput.readShort();
+                            keyLen = dataInput.readByte();
                         } catch (EOFException ignored) {
                             return false;
                         }
-                        dataInput.readFully(inputBuff, 0, entryLen - 8);
+                        dataInput.readFully(inputBuff, 0, keyLen);
                         long pointer = dataInput.readLong();
-                        current = new KeyPointer(pointer, inputBuff, entryLen - 8);
+                        current = new KeyPointer(pointer, inputBuff, keyLen);
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }

--- a/bam-index/src/main/java/org/victorchang/KeyPointerWriter.java
+++ b/bam-index/src/main/java/org/victorchang/KeyPointerWriter.java
@@ -53,7 +53,7 @@ public class KeyPointerWriter {
                     count = 0;
                 }
             }
-            dataOutput.writeShort(x.getKey().length + 8);
+            dataOutput.writeByte(x.getKey().length);
             dataOutput.write(x.getKey());
             dataOutput.writeLong(x.getPointer());
             count++;


### PR DESCRIPTION
Because the pointer size is fixed, we don't need to include it in the
length. QNAME is limited to 254 characters, so it fits into one byte:

<img width="939" alt="Screen Shot 2020-09-25 at 15 34 23" src="https://user-images.githubusercontent.com/16778/94230208-d1be7380-ff44-11ea-9174-093353db6bbf.png">
