### PR TITLE
Fix reading QNAMEs longer than 127 bytes

### DIFF
--- a/bam-index/src/main/java/org/victorchang/KeyPointerReader.java
+++ b/bam-index/src/main/java/org/victorchang/KeyPointerReader.java
@@ -45,7 +45,7 @@ public class KeyPointerReader {
                     try {
                         int keyLen;
                         try {
-                            keyLen = dataInput.readByte();
+                            keyLen = dataInput.readUnsignedByte();
                         } catch (EOFException ignored) {
                             return false;
                         }

--- a/bam-index/src/test/java/org/victorchang/KeyPointerWriteReadTest.java
+++ b/bam-index/src/test/java/org/victorchang/KeyPointerWriteReadTest.java
@@ -1,6 +1,7 @@
 package org.victorchang;
 
 
+import com.google.common.base.Strings;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -37,5 +38,28 @@ public class KeyPointerWriteReadTest {
         input.close();
 
         assertThat(read, equalTo(written));
+    }
+
+    @Test
+    public void testLongName() throws IOException {
+        KeyPointerWriter writer = new KeyPointerWriter();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        // 254 is the max length of a QNAME
+        String name = Strings.repeat("A", 254);
+        byte[] qname = Ascii7Coder.INSTANCE.encode(name);
+
+        List<KeyPointer> pointers = List.of(new KeyPointer(36300895L, 59353, qname, qname.length));
+
+        writer.write(output, pointers.stream());
+        output.close();
+
+        KeyPointerReader reader = new KeyPointerReader();
+        ByteArrayInputStream input = new ByteArrayInputStream(output.toByteArray());
+
+        List<KeyPointer> read = reader.read(input).collect(Collectors.toList());
+        input.close();
+
+        assertThat(read, equalTo(pointers));
     }
 }


### PR DESCRIPTION
Java's signed bytes strike again.